### PR TITLE
Sierra

### DIFF
--- a/tools/common.sh
+++ b/tools/common.sh
@@ -128,8 +128,14 @@ function _genSMBIOSData()
 		exit 1
 	fi
 
-	serialNumber=$("$gRepo/modules/MacGen/simpleMacSerial.sh" $gProductName)
-	MLB=$("$gRepo/modules/MacGen/simpleMLBSerial.sh" $gProductName $serialNumber)
+	serialNumber=$("$gRepo/modules/MacGen/mg-serial" $gProductName)
+	# shorten to last 12 characters in case of debug output
+	serialNumber=${serialNumber:(-12)}
+	
+	MLB=$("$gRepo/modules/MacGen/mg-mlb-serial" $gProductName $serialNumber)
+	# shorten to last 17 characters in case of debug output
+	MLB=${MLB:(-17)}
+	
 	smUUID=$(uuidgen)
 
 	echo " - Product Name: $gProductName"


### PR DESCRIPTION
This pull request for the sierra branch does 2 things as two separate commits so you can cherry pick it if you want. 
1. It just updates MacGen submodule to point to your newest version of MacGen, instead of MacGen @ 3498923.  
2. It updates the common.sh file to work with the newer version of MacGen and truncates the output to the last 12/17 characters for the serial/mlb which handles the case of debug output

The current version of the sierra script (before this pull request) actually ends up pulling down the newest version of MacGen anyway before the main part of the script runs, via the update feature you have in it (assuming you have internet when it's run). This is actually the cause of the initial post in Issue #45 as well as the solution 😃 

thanks for making and sharing this set of scripts patches etc for the gigabyte boards. 